### PR TITLE
updating version of import packages for CDI 2.0

### DIFF
--- a/module/osgi-cdi/osgi.bundle
+++ b/module/osgi-cdi/osgi.bundle
@@ -40,7 +40,7 @@
 
 # Yes, we export with version 1.0
 Export-Package: org.glassfish.osgicdi; version=1.0
-Import-Package: javax.inject; version="[1.0, 2.0)", \
-                javax.enterprise.*; version="[1.0, 2.0)", \
+Import-Package: javax.inject; version="[1.0, 3.0)", \
+                javax.enterprise.*; version="[1.0, 3.0)", \
                 org.glassfish.osgicdi; version="[1.0, 2.0)", \
                 *


### PR DESCRIPTION
For CDI 2.0 integration with Glassfish, need to update the version of import packages.