### PR TITLE
Added a check to prevent excessive bundle redeployment.

### DIFF
--- a/module/osgi-javaee-base/src/main/java/org/glassfish/osgijavaeebase/OSGiContainer.java
+++ b/module/osgi-javaee-base/src/main/java/org/glassfish/osgijavaeebase/OSGiContainer.java
@@ -107,7 +107,11 @@ public class OSGiContainer {
 
     private synchronized OSGiApplicationInfo redeploy(Bundle b) throws Exception {
         if (isShutdown()) return null;
-        if (isDeployed(b)) {
+        OSGiApplicationInfo appInfo = applications.get(b);
+        if (appInfo != null) {
+            ServiceReference newDeployer = selectDeployer(b), oldDeployer = appInfo.getDeployer();
+            if (newDeployer == oldDeployer || newDeployer != null && newDeployer.equals(oldDeployer))
+                return appInfo;
             undeploy(b);
         }
         return deploy(b);


### PR DESCRIPTION
Bundle is not redeployed in case it was previously deployed using the same `OSGiDeployer`
 Fixes #6